### PR TITLE
sorry for the ugly solution

### DIFF
--- a/multifolderclone.py
+++ b/multifolderclone.py
@@ -98,7 +98,7 @@ def rcopy(source, dest, sname,pre):
             "mimeType": "application/vnd.google-apps.folder",
             "parents": [dest]
         }, supportsAllDrives=True).execute()
-        rcopy(i["id"], resp["id"], i["name"],nstu)
+        rcopy(i["id"], resp["id"], i["name"].replace('%',"%%"),nstu)
         s += 1
 
 httplib2shim.patch()


### PR DESCRIPTION
for cases on which a folder name contains a literal % and python insists on throwing an "unsupported format character" exception