### PR TITLE
Fix Error When Running

### DIFF
--- a/masshare.py
+++ b/masshare.py
@@ -32,7 +32,7 @@ drive = googleapiclient.discovery.build("drive", "v3", credentials=credentials)
 batch = drive.new_batch_http_request()
 
 aa = glob.glob('%s/*.json' % acc_dir)
-pbar = progress.bar.Bar("Readying accounts" % did,max=len(aa))
+pbar = progress.bar.Bar("Readying accounts",max=len(aa))
 for i in aa:
 	ce = json.loads(open(i,'r').read())['client_email']
 	batch.add(drive.permissions().create(fileId=did, supportsAllDrives=True, body={


### PR DESCRIPTION
Fixes "TypeError: not all arguments converted during string formatting" when running script.

This commit will fix the issue or adding %s back to the string will fix it.